### PR TITLE
#18 share target picker

### DIFF
--- a/app/assets/stylesheets/share_target_pickers.scss
+++ b/app/assets/stylesheets/share_target_pickers.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the ShareTargetPickers controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,11 @@ class ApplicationController < ActionController::Base
 
   private
 
-  def set_liff_id
-    gon.liff_id = ENV['LIFF_ID']
+  def set_login_liff_id
+    gon.liff_id = ENV['LIFF_ID_LOGIN']
+  end
+
+  def set_share_target_picker_liff_id
+    gon.liff_id = ENV['LIFF_ID_SHARE_TARGET_PICKER']
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -18,7 +18,6 @@ class GroupsController < ApplicationController
       req["Authorization"] = "Bearer {#{ENV['LINEBOT_CHANNEL_TOKEN']}}"
       res = http.request(req)
 
-      binding.pry
       redirect_to root_path
     else
       render :new

--- a/app/controllers/share_target_pickers_controller.rb
+++ b/app/controllers/share_target_pickers_controller.rb
@@ -1,0 +1,8 @@
+class ShareTargetPickersController < ApplicationController
+  before_action :set_share_target_picker_liff_id
+
+  def login ;end
+
+  def new
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,21 +1,23 @@
 class UsersController < ApplicationController
-  before_action :set_liff_id
+  before_action :set_login_liff_id, only: [:login]
 
   require 'net/http'
   require 'uri'
   
-  def login; end
-
+  def login
+    binding.pry
+  end
   def new
     
   end
   
   def create
     idToken = params[:idToken]
-    channelId = '1656693818'
+    channelId = ENV['LIFF_CHANNEL_ID']
     res = Net::HTTP.post_form(URI.parse('https://api.line.me/oauth2/v2.1/verify'),{'id_token'=>idToken, 'client_id'=>channelId})
     line_user_id = JSON.parse(res.body)["sub"]
     user = User.find_by(line_id: line_user_id)
+    binding.pry
     if user.nil?
         #もしパラメーターがあるならば、そのパラメーター持つのuserの所属するgroupに入れる
         #無ければ↓
@@ -24,6 +26,8 @@ class UsersController < ApplicationController
         session[:user_id] = user.id
     else
         session[:user_id] = user.id
+        uuid = { id: user.line_id }
+        render json: uuid
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,7 +5,6 @@ class UsersController < ApplicationController
   require 'uri'
   
   def login
-    binding.pry
   end
   def new
     
@@ -17,10 +16,14 @@ class UsersController < ApplicationController
     res = Net::HTTP.post_form(URI.parse('https://api.line.me/oauth2/v2.1/verify'),{'id_token'=>idToken, 'client_id'=>channelId})
     line_user_id = JSON.parse(res.body)["sub"]
     user = User.find_by(line_id: line_user_id)
-    binding.pry
+
+    if params[:uuid]
+      link_user = user.find_by(uuid: params[:uuid])
+      user = User.create!(line_id: line_user_id, group: link_user.group_id)
+      return
+    end
+
     if user.nil?
-        #もしパラメーターがあるならば、そのパラメーター持つのuserの所属するgroupに入れる
-        #無ければ↓
         group = Group.create!
         user = User.create!(line_id: line_user_id, group: group)
         session[:user_id] = user.id

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,8 +18,9 @@ class UsersController < ApplicationController
     user = User.find_by(line_id: line_user_id)
 
     if params[:uuid]
-      link_user = user.find_by(uuid: params[:uuid])
-      user = User.create!(line_id: line_user_id, group: link_user.group_id)
+      link_user = User.find_by(uuid: params[:uuid])
+      user = User.create!(line_id: line_user_id, group: link_user.group)
+      session[:user_id] = user.id
       return
     end
 
@@ -29,7 +30,7 @@ class UsersController < ApplicationController
         session[:user_id] = user.id
     else
         session[:user_id] = user.id
-        uuid = { id: user.line_id }
+        uuid = { id: user.uuid }
         render json: uuid
     end
   end

--- a/app/helpers/share_target_pickers_helper.rb
+++ b/app/helpers/share_target_pickers_helper.rb
@@ -1,0 +1,2 @@
+module ShareTargetPickersHelper
+end

--- a/app/javascript/packs/share_target_picker/login.js
+++ b/app/javascript/packs/share_target_picker/login.js
@@ -1,0 +1,49 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+  liff.init({
+    liffId: gon.liff_id
+  })
+  .then(() => {
+    if (!liff.isLoggedIn()) {
+      // 開発時、外部ブラウザからアクセスために利用
+      liff.login();
+    }
+  })
+  .then(() => {
+    const idToken = liff.getIDToken();
+    const body = `idToken=${idToken}`
+    const request = new Request('/users', {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+        'X-CSRF-Token': token
+        },
+        method: 'POST',
+        body: body
+        });
+    fetch(request)
+    .then(response => {
+      console.log(response.json); // => 200
+      return response.json().then(response_uuid => {
+        // JSONパースされたオブジェクトが渡される
+        var uuid = response_uuid ;
+        debugger;
+        if (liff.isApiAvailable('shareTargetPicker')) {
+          const url = `https://liff.line.me/1656693818-N2kw6Bvk?q=${uuid.id}`
+          liff.shareTargetPicker([{
+            type: "text",
+            text: url
+            },
+          ],
+          ).catch(function (res) {
+            //「シェアターゲットピッカー」が有効になっているが取得に失敗した場合 
+            console.log('LINEのバージョンが古い可能性があります');
+          });
+        } else {
+          //「シェアターゲットピッカー」が無効になっている場合
+          console.log('「シェアターゲットピッカー」が無効になっています');
+        }
+      })
+    })
+  })
+})

--- a/app/javascript/packs/users/login.js
+++ b/app/javascript/packs/users/login.js
@@ -11,6 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   })
   .then(() => {
+    debugger;
     const idToken = liff.getIDToken();
     const body = `idToken=${idToken}`
     const request = new Request('/users', {

--- a/app/javascript/packs/users/login.js
+++ b/app/javascript/packs/users/login.js
@@ -11,9 +11,14 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   })
   .then(() => {
-    debugger;
+    var param = getParam('q')
     const idToken = liff.getIDToken();
-    const body = `idToken=${idToken}`
+    if(!param){
+      var body = `idToken=${idToken}`
+    }else{
+      var body = `idToken=${idToken}&uuid=${param}`
+    }
+    debugger;
     const request = new Request('/users', {
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
@@ -28,3 +33,13 @@ document.addEventListener('DOMContentLoaded', () => {
     })
   })
 })
+
+function getParam(name, url) {
+  if (!url) url = window.location.href;
+  name = name.replace(/[\[\]]/g, "\\$&");
+  var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+      results = regex.exec(url);
+  if (!results) return null;
+  if (!results[2]) return '';
+  return decodeURIComponent(results[2].replace(/\+/g, " "));
+}

--- a/app/javascript/packs/users/login.js
+++ b/app/javascript/packs/users/login.js
@@ -18,7 +18,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }else{
       var body = `idToken=${idToken}&uuid=${param}`
     }
-    debugger;
     const request = new Request('/users', {
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,4 +1,7 @@
 class Group < ApplicationRecord
   has_many :users
-  accepts_nested_attributes_for :users, allow_destroy: true
+  accepts_nested_attributes_for :users
+
+  validates :last_name, length: { maximum: 20 }, allow_nil: true
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,5 @@
 class User < ApplicationRecord
   belongs_to :group
+
+  before_create -> { self.uuid = SecureRandom.uuid }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,10 @@
 class User < ApplicationRecord
   belongs_to :group
 
+  validates :line_id, presence: true, uniqueness: true
+  validates :sound_rate_setting, numericality: { in: 1..5  }, allow_nil: true
+  validates :character_rate_setting, numericality: { in: 1..5  }, allow_nil: true
+  validates :fotune_telling_rate_setting, numericality: { in: 1..5  }, allow_nil: true
+
   before_create -> { self.uuid = SecureRandom.uuid }
 end

--- a/app/views/share_target_pickers/new.html.slim
+++ b/app/views/share_target_pickers/new.html.slim
@@ -1,0 +1,4 @@
+<h1>ShareTargetPickers#new</h1>
+<p>Find me in app/views/share_target_pickers/new.html.erb</p>
+
+= javascript_pack_tag 'share_target_picker/login'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
 
   resources :users, only: [:new, :create]
   resources :groups, only: [:new, :update]
+  resources :share_target_pickers, only: [:new]
 end

--- a/spec/helpers/share_target_pickers_helper_spec.rb
+++ b/spec/helpers/share_target_pickers_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the ShareTargetPickersHelper. For example:
+#
+# describe ShareTargetPickersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe ShareTargetPickersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/share_target_pickers_spec.rb
+++ b/spec/requests/share_target_pickers_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "ShareTargetPickers", type: :request do
+  describe "GET /new" do
+    it "returns http success" do
+      get "/share_target_pickers/new"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/share_target_pickers/new.html.erb_spec.rb
+++ b/spec/views/share_target_pickers/new.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "share_target_pickers/new.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要

share_target_picker用のコントローラー・view・jsを作成
紐つけ元のユーザーからshare_target_pickerを使用してLIFFのurlを送信→送られた人はurlを踏むことでユーザーが同じグループ
で登録されるように設定

