### PR TITLE
#50 bug during name registration

### DIFF
--- a/app/helpers/rates_helper.rb
+++ b/app/helpers/rates_helper.rb
@@ -3,7 +3,7 @@ module RatesHelper
     return if rates.blank?
     sum = 0
     rates.each do |rate|
-      sum += rate.sound_rate
+      sum += rate.sound_rate.to_i
     end
     average = sum / rates.length
     # 0.5刻みに評価の数値を丸める
@@ -17,7 +17,7 @@ module RatesHelper
     return if rates.blank?
     sum = 0
     rates.each do |rate|
-      sum = rate.character_rate
+      sum += rate.character_rate.to_i
     end
     average = sum / rates.length.to_f
     # 0.5刻みに評価の数値を丸める

--- a/app/models/first_name.rb
+++ b/app/models/first_name.rb
@@ -18,10 +18,10 @@ class FirstName < ApplicationRecord
           user_count -= 1
           next
         end
-        # userの評価基準と、実際の評価を掛け合わせて総評価の点をsumで出力
-        sound_rate = rate.sound_rate * user.sound_rate_setting
-        character_rate = rate.character_rate * user.character_rate_setting
-        fotune_telling_rate = first_name.fotune_telling_rate * user.fotune_telling_rate_setting
+        # userの評価基準と、実際の評価(rate)を掛け合わせて総評価の点をsumで出力
+        sound_rate = rate.sound_rate.to_i * user.sound_rate_setting.to_i
+        character_rate = rate.character_rate.to_i * user.character_rate_setting.to_i
+        fotune_telling_rate = first_name.fotune_telling_rate.to_i * user.fotune_telling_rate_setting.to_i
         sum = sound_rate + character_rate + fotune_telling_rate
       end
       if user_count.zero?


### PR DESCRIPTION
## 概要

メッセージで名前登録中に名前一覧に飛ぶとエラーが発生するバグを解消。
rateがnilのカラムがある場合にエラーになっていたので、to_iでnilの場合0に変換するように設定。

## 確認方法

名前登録で漢字の評価の時点で名前一覧に飛ぶとエラーが発生していたが、
解消されている。