### PR TITLE
#108 user reset function

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -30,4 +30,15 @@ class UsersController < ApplicationController
     end
     session[:user_id] = user.id
   end
+
+  def destroy
+    user = User.find(session[:user_id])
+    leave_group = user.group
+    new_group = Group.create!
+    user.likes.delete_all
+    user.rates.delete_all
+    user.update!(group: new_group, status: 'normal', editing_name_id: nil, sound_rate_setting: nil, character_rate_setting: nil, fotune_telling_rate_setting: nil)
+    leave_group.destroy if leave_group.users.empty?
+    redirect_to new_user_path, success: 'ユーザー情報のリセットに成功しました'
+  end
 end

--- a/app/models/linebot.rb
+++ b/app/models/linebot.rb
@@ -32,9 +32,14 @@ class Linebot
           case @user.status
           when 'normal'
             if replied_message == '名前を新規登録'
-              @message.send_message_in_characters
-              client.reply_message(event['replyToken'], @message.object)
-              @user.name_add!
+              if @user.group.last_name.nil?
+                @message.registration_last_name
+                client.reply_message(event['replyToken'], @message.object)
+              else
+                @message.send_message_in_characters
+                client.reply_message(event['replyToken'], @message.object)
+                @user.name_add!
+              end
             else
               search_name = FirstName.find_by(group_id: @user.group.id, name: replied_message)
               if search_name.nil?

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -5,7 +5,15 @@ class Message
     @object =
       {
         type: 'text',
-        text: 'メニューバーの始めるからユーザー登録を行なってね'
+        text: 'メニューバーの「START」からユーザー登録を行なってね'
+      }
+  end
+
+  def registration_last_name
+    @object =
+      {
+        type: 'text',
+        text: 'メニューの「ユーザー設定」から姓を登録してね'
       }
   end
 
@@ -21,7 +29,7 @@ class Message
     @object =
       {
         type: 'text',
-        text: 'メニューバーから「新規登録」で名前候補を登録できるよ/登録された名前を漢字で送ると、姓名判断の結果を返すよ'
+        text: 'メニューバーから「新規登録」で名前候補を登録できるよ / 登録された名前を漢字で送ると、姓名判断の結果を返すよ'
       }
   end
 

--- a/app/views/groups/new.html.slim
+++ b/app/views/groups/new.html.slim
@@ -1,7 +1,7 @@
 
 - set_meta_tags title: t('.title')
 .container-xs
-  .col-lg-8.px-5.py-3
+  .col-lg-8.px-5.py-3.under-line-dot
     h1.title.text-center.fw-bold = t('.title')
     = form_with model: @group, local: true do |f|
       .form-group.pt-3
@@ -42,7 +42,11 @@
               = u.label :fotune_telling_rate_setting_2, t('defaults.usual'), class: "btn outline btn-dark mx-2"
               = u.radio_button :fotune_telling_rate_setting, 1, class: "btn-check", autocomplete: "off"
               = u.label :fotune_telling_rate_setting_1, t('defaults.row'), class: "btn outline btn-dark mx-2"
-
       .col.text-center.mt-3
         = f.submit (t 'defaults.register'), class: "btn btn-dark fs-1"
-
+  .col.pt-5
+    h1.title.text-center.fw-bold ユーザー情報リセット
+    .text-center.pt-2
+      | 名前一覧の情報がリセットされます。<br>アカウント共有している場合、共有が解除されます。
+  .col.py-4.text-center
+    = link_to 'ユーザーリセット', user_path(@user), method: :delete, class: 'btn btn-danger fs-4', data: {confirm: "リセットしてよろしいですか？"}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   post 'share_target_pickers/login', to: 'share_target_pickers#login'
   post 'callback', to: 'line_bot#callback'
   get '/sitemap', to: redirect("https://s3-ap-northeast-1.amazonaws.com/#{ENV['AWS_BUCKET']}/sitemap.xml.gz")
-  resources :users, only: %i[new create]
+  resources :users, only: %i[new create destroy]
   resources :groups, only: %i[new update] do
     resources :first_names, only: %i[index]
   end


### PR DESCRIPTION
## 概要

ユーザーリセット機能の追加
→もしアカウント共有している場合は共有解除。1人の場合はgroupを削除

ユーザー削除して、姓を登録してない状態で名前を登録できないように
Line_botモデルを修正